### PR TITLE
logMessages:Consideration of single message

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -901,13 +901,20 @@ class DAIA extends AbstractBase implements
      */
     protected function logMessages($messages, $context)
     {
-        foreach ($messages as $message) {
-            if (isset($message['content'])) {
-                $this->debug(
-                    "Message in DAIA response (" . (string) $context . "): " .
-                    $message['content']
-                );
-            }
-        }
+		if (isset($messages['content'])) {
+			$this->debug(
+				"Message in DAIA response (" . (string) $context . "): " .
+				$messages['content']
+			);		
+		} else {
+			foreach ($messages as $message) {
+				if (isset($message['content'])) {
+					$this->debug(
+						"Message in DAIA response (" . (string) $context . "): " .
+						$message['content']
+					);
+				}
+			}
+		}
     }
 }


### PR DESCRIPTION
logMessages only considers arrays of message arrays, so if just one message array is passed to logMessages putting it into the loop would remove keys and so it's content would not be found.
