### PR TITLE
getItemCallnumber - empty check for label

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -846,7 +846,7 @@ class DAIA extends AbstractBase implements
      */
     protected function getItemCallnumber($item)
     {
-        return array_key_exists("label", $item)
+         return array_key_exists("label", $item) && !empty($item['label'])
             ? $item['label']
             : "Unknown";
     }


### PR DESCRIPTION
If a label exists, but is empty, this error will be trigger: error: Array provided to Escape helper, but flags do not allow recursion. An empty label results in function pickValue in module/VuFind/src/VuFind/Controller/AjaxController.php#L291 receiving an empty array within an array while only expecting an array of strings.
